### PR TITLE
Remove 'Continue as Guest' button from reservation login page

### DIFF
--- a/frontend/src/components/customer/CustomerLoginForm.tsx
+++ b/frontend/src/components/customer/CustomerLoginForm.tsx
@@ -11,8 +11,7 @@ import {
   InputAdornment,
   IconButton,
   FormControlLabel,
-  Checkbox,
-  Divider
+  Checkbox
 } from '@mui/material';
 import {
   Visibility,
@@ -194,18 +193,6 @@ export const CustomerLoginForm: React.FC<CustomerLoginFormProps> = ({
           sx={{ mt: 2, mb: 2 }}
         >
           {loading ? <CircularProgress size={24} /> : 'Sign In'}
-        </Button>
-
-        <Divider sx={{ my: 3 }}>OR</Divider>
-
-        <Button
-          fullWidth
-          variant="outlined"
-          size="large"
-          onClick={() => navigate(buildCustomerUrl('reservations/new'))}
-          sx={{ mb: 2 }}
-        >
-          Continue as Guest
         </Button>
 
         <Typography variant="body2" align="center">


### PR DESCRIPTION
- Removed guest reservation option to require account registration
- Removed OR divider and Continue as Guest button
- Cleaned up unused Divider import

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the "Continue as Guest" option and divider from `CustomerLoginForm.tsx`, requiring account sign-in.
> 
> - **Frontend**
>   - **Customer Login (`frontend/src/components/customer/CustomerLoginForm.tsx`)**:
>     - Remove `Divider` and "Continue as Guest" button.
>     - Clean up related imports.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cca86a3e10648fc9561b2c9e4fe60178e487725b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->