### PR TITLE
Fix reservation list view date display: Use UTC date components

### DIFF
--- a/frontend/src/pages/ReservationManagementPage.tsx
+++ b/frontend/src/pages/ReservationManagementPage.tsx
@@ -101,12 +101,21 @@ const ReservationFormDialog: React.FC<ReservationFormDialogProps> = ({
 
   useEffect(() => {
     if (reservation) {
+      // Format date using UTC components to ensure correct date display in form
+      // Reservation dates are stored as UTC midnight, so we extract UTC components
+      const resDate = new Date(reservation.reservationDate);
+      const displayDate = new Date(
+        resDate.getUTCFullYear(),
+        resDate.getUTCMonth(),
+        resDate.getUTCDate()
+      );
+      
       setFormData({
         customerName: reservation.customerName,
         customerEmail: reservation.customerEmail || '',
         customerPhone: reservation.customerPhone || '',
         partySize: reservation.partySize,
-        reservationDate: format(parseISO(reservation.reservationDate), 'yyyy-MM-dd'),
+        reservationDate: format(displayDate, 'yyyy-MM-dd'),
         reservationTime: reservation.reservationTime,
         status: reservation.status,
         notes: reservation.notes || '',
@@ -740,7 +749,18 @@ const ReservationManagementPage: React.FC = () => {
               </Typography>
               <Typography variant="body2" color="text.secondary" sx={{ display: 'flex', alignItems: 'center', mt: 0.5 }}>
                 <CalendarIcon fontSize="small" sx={{ mr: 0.5 }} />
-                {format(parseISO(reservation.reservationDate), 'MMM d, yyyy')}
+                {(() => {
+                  // Format date using UTC components to ensure correct date display
+                  // Reservation dates are stored as UTC midnight, so we extract UTC components
+                  const resDate = new Date(reservation.reservationDate);
+                  // Create a local date with UTC components to display correctly
+                  const displayDate = new Date(
+                    resDate.getUTCFullYear(),
+                    resDate.getUTCMonth(),
+                    resDate.getUTCDate()
+                  );
+                  return format(displayDate, 'MMM d, yyyy');
+                })()}
               </Typography>
               <Typography variant="body2" color="text.secondary" sx={{ display: 'flex', alignItems: 'center', mt: 0.5 }}>
                 <TimeIcon fontSize="small" sx={{ mr: 0.5 }} />
@@ -1111,7 +1131,18 @@ const ReservationManagementPage: React.FC = () => {
                   <TableCell>
                     <Box display="flex" alignItems="center">
                       <CalendarIcon fontSize="small" sx={{ mr: 1 }} />
-                      {format(parseISO(reservation.reservationDate), 'MMM d, yyyy')}
+                      {(() => {
+                        // Format date using UTC components to ensure correct date display
+                        // Reservation dates are stored as UTC midnight, so we extract UTC components
+                        const resDate = new Date(reservation.reservationDate);
+                        // Create a local date with UTC components to display correctly
+                        const displayDate = new Date(
+                          resDate.getUTCFullYear(),
+                          resDate.getUTCMonth(),
+                          resDate.getUTCDate()
+                        );
+                        return format(displayDate, 'MMM d, yyyy');
+                      })()}
                     </Box>
                   </TableCell>
                   <TableCell>


### PR DESCRIPTION
- Fix desktop table view to display correct date using UTC components
- Fix mobile card view to display correct date using UTC components
- Fix form date input to use UTC components when editing reservations
- Ensures dates match calendar view and email confirmations
- Prevents timezone issues showing December 31 as December 30

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use UTC date components to display reservation dates correctly in the edit form, mobile cards, and desktop table, avoiding timezone off-by-one issues.
> 
> - **Frontend**
>   - `frontend/src/pages/ReservationManagementPage.tsx`
>     - **Date handling**: Format `reservationDate` using UTC components to ensure correct local display.
>       - Edit form date input
>       - Mobile card date text
>       - Desktop table date column
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f5e9d67feaa3307311f42101ffa075e3b6a767a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->