### PR TITLE
fix: remove insecure JWT secret fallbacks to prevent auth mismatch

### DIFF
--- a/backend/src/controllers/authController.ts
+++ b/backend/src/controllers/authController.ts
@@ -3,8 +3,14 @@ import bcrypt from 'bcryptjs';
 import jwt from 'jsonwebtoken';
 import prisma from '../config/db';
 
-// Get JWT secret from environment variables
-const JWT_SECRET = process.env.JWT_SECRET || 'your-secret-key';
+// Get JWT secret from environment variables - must be configured
+const getJwtSecret = (): string => {
+  const secret = process.env.JWT_SECRET;
+  if (!secret) {
+    throw new Error('JWT_SECRET environment variable is not configured');
+  }
+  return secret;
+};
 
 export const register = async (req: Request, res: Response) => {
     try {
@@ -33,7 +39,7 @@ export const register = async (req: Request, res: Response) => {
         // Create token
         const token = jwt.sign(
             { id: user.id, email: user.email, role: user.role },
-            JWT_SECRET,
+            getJwtSecret(),
             { expiresIn: '24h' }
         );
 
@@ -70,7 +76,7 @@ export const login = async (req: Request, res: Response) => {
         // Create token
         const token = jwt.sign(
             { id: user.id, email: user.email, role: user.role },
-            JWT_SECRET,
+            getJwtSecret(),
             { expiresIn: '24h' }
         );
 

--- a/backend/src/controllers/platform/authController.ts
+++ b/backend/src/controllers/platform/authController.ts
@@ -6,8 +6,14 @@ import prisma from '../../config/db';
 
 dotenv.config();
 
-// Separate JWT secret for platform admins
-const PLATFORM_JWT_SECRET = process.env.PLATFORM_JWT_SECRET || process.env.JWT_SECRET || 'platform-secret-key';
+// Get platform JWT secret from environment variables - must be configured
+const getPlatformJwtSecret = (): string => {
+  const secret = process.env.PLATFORM_JWT_SECRET || process.env.JWT_SECRET;
+  if (!secret) {
+    throw new Error('PLATFORM_JWT_SECRET or JWT_SECRET environment variable must be configured');
+  }
+  return secret;
+};
 const PLATFORM_JWT_EXPIRES_IN = '24h';
 
 interface PlatformAuthRequest extends Request {
@@ -69,7 +75,7 @@ export const platformLogin = async (req: Request, res: Response): Promise<void> 
         role: admin.role,
         type: 'platform',
       },
-      PLATFORM_JWT_SECRET,
+      getPlatformJwtSecret(),
       { expiresIn: PLATFORM_JWT_EXPIRES_IN }
     );
 

--- a/backend/src/middleware/platformAuth.ts
+++ b/backend/src/middleware/platformAuth.ts
@@ -4,7 +4,15 @@ import dotenv from 'dotenv';
 import prisma from '../config/db';
 
 dotenv.config();
-const PLATFORM_JWT_SECRET = process.env.PLATFORM_JWT_SECRET || process.env.JWT_SECRET || 'platform-secret-key';
+
+// Get platform JWT secret from environment variables - must be configured
+const getPlatformJwtSecret = (): string => {
+  const secret = process.env.PLATFORM_JWT_SECRET || process.env.JWT_SECRET;
+  if (!secret) {
+    throw new Error('PLATFORM_JWT_SECRET or JWT_SECRET environment variable must be configured');
+  }
+  return secret;
+};
 
 export interface PlatformAuthRequest extends Request {
   platformAdmin?: {
@@ -29,7 +37,7 @@ export const platformAuth = async (
     }
 
     // Verify token
-    const decoded = jwt.verify(token, PLATFORM_JWT_SECRET) as any;
+    const decoded = jwt.verify(token, getPlatformJwtSecret()) as any;
 
     // Check if it's a platform token
     if (decoded.type !== 'platform') {

--- a/backend/src/utils/tokenUtils.ts
+++ b/backend/src/utils/tokenUtils.ts
@@ -1,8 +1,18 @@
 import crypto from 'crypto';
 import jwt from 'jsonwebtoken';
 
-const JWT_SECRET = process.env.JWT_SECRET || 'your-secret-key';
-const REFRESH_TOKEN_SECRET = process.env.REFRESH_TOKEN_SECRET || JWT_SECRET;
+// Get JWT secret from environment variables - must be configured
+const getJwtSecret = (): string => {
+  const secret = process.env.JWT_SECRET;
+  if (!secret) {
+    throw new Error('JWT_SECRET environment variable is not configured');
+  }
+  return secret;
+};
+
+const getRefreshTokenSecret = (): string => {
+  return process.env.REFRESH_TOKEN_SECRET || getJwtSecret();
+};
 
 interface TokenPayload {
   userId: number;
@@ -20,23 +30,23 @@ export function generateSecureToken(length: number = 32): string {
 }
 
 export function generateAccessToken(payload: TokenPayload): string {
-  return jwt.sign(payload, JWT_SECRET, {
+  return jwt.sign(payload, getJwtSecret(), {
     expiresIn: '1h' // Access token expires in 1 hour
   });
 }
 
 export function generateRefreshToken(payload: RefreshTokenPayload): string {
-  return jwt.sign(payload, REFRESH_TOKEN_SECRET, {
+  return jwt.sign(payload, getRefreshTokenSecret(), {
     expiresIn: '30d' // Refresh token expires in 30 days
   });
 }
 
 export function verifyAccessToken(token: string): TokenPayload {
-  return jwt.verify(token, JWT_SECRET) as TokenPayload;
+  return jwt.verify(token, getJwtSecret()) as TokenPayload;
 }
 
 export function verifyRefreshToken(token: string): RefreshTokenPayload {
-  return jwt.verify(token, REFRESH_TOKEN_SECRET) as RefreshTokenPayload;
+  return jwt.verify(token, getRefreshTokenSecret()) as RefreshTokenPayload;
 }
 
 export function generateEmailVerificationToken(): string {


### PR DESCRIPTION
- authController.ts: Replace hardcoded 'your-secret-key' fallback with getJwtSecret() that throws if JWT_SECRET is not configured
- tokenUtils.ts: Replace hardcoded fallbacks with getter functions that require JWT_SECRET to be set
- platformAuth.ts: Replace 'platform-secret-key' fallback with getPlatformJwtSecret() that requires PLATFORM_JWT_SECRET or JWT_SECRET
- platform/authController.ts: Same fix for platform admin authentication

This fixes the issue where tokens signed with fallback secrets would fail verification in authMiddleware.ts (which properly throws when JWT_SECRET is missing), causing authentication to silently break.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Strengthens auth by eliminating default JWT secrets and requiring explicit env configuration.
> 
> - Replace secret constants with `getJwtSecret()` and `getPlatformJwtSecret()` in `authController.ts`, `platform/authController.ts`, and `middleware/platformAuth.ts`; all `jwt.sign`/`jwt.verify` now use these getters
> - Update `utils/tokenUtils.ts` to use `getJwtSecret()` for access tokens and new `getRefreshTokenSecret()` for refresh tokens across `sign`/`verify`
> - Removes silent secret fallbacks, preventing token mismatch and ensuring clear failures when `JWT_SECRET`/`PLATFORM_JWT_SECRET` are unset
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d9b9d44f5e559447a8719c41a45fd513b03e4cd7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->